### PR TITLE
Add protection of strings to prevent hijacking of deepl credits. POC!

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -13,6 +13,7 @@ use YDPL\Providers\AssetsServiceProvider;
 use YDPL\Providers\MetaBoxServiceProvider;
 use YDPL\Providers\RestAPIServiceProvider;
 use YDPL\Providers\SettingsServiceProvider;
+use YDPL\Providers\TextExtractionServiceProvider;
 use YDPL\Vendor_Prefixed\DI\ContainerBuilder;
 use YDPL\Vendor_Prefixed\Psr\Container\ContainerInterface;
 
@@ -71,6 +72,7 @@ class Bootstrap
 			new SettingsServiceProvider(),
 			new RestAPIServiceProvider(),
 			new MetaBoxServiceProvider(),
+			new TextExtractionServiceProvider(),
 		);
 	}
 

--- a/src/Controllers/RestAPIController.php
+++ b/src/Controllers/RestAPIController.php
@@ -51,7 +51,17 @@ class RestAPIController
 
 		// Secure mode prevents hijacking the DeepL credits.
 		if ( $this->options->secure_mode_enabled() ) {
-			$text_allowed = $this->texts->get_allowed_text( (int) $object_id );
+			if ( is_numeric( $object_id ) && (int) $object_id > 0 ) {
+				$object = "post-" . $object_id;
+			} else {
+				// get referer from request
+				$url = $request->get_header( 'referer' ) ?? false;
+				if ( $url ) {
+					$object = "url-{$url}";
+				}
+			}
+
+			$text_allowed = $this->texts->get_allowed_text( $object );
 			if ( $text ) {
 				// In case we send texts to translate, only allow the ones that are actually in the content.
 				$text = $this->texts->array_intersect_loose( $text, $text_allowed );

--- a/src/Controllers/RestAPIController.php
+++ b/src/Controllers/RestAPIController.php
@@ -56,9 +56,15 @@ class RestAPIController
 			} else {
 				// get referer from request
 				$url = $request->get_header( 'referer' ) ?? false;
-				if ( $url ) {
+				$url_host = preg_replace( '/^www\./', '', wp_parse_url( $url, PHP_URL_HOST ) );
+				$website_host = preg_replace( '/^www\./', '', wp_parse_url( home_url(), PHP_URL_HOST ) );
+				// make sure the URL in on the same domain as this website.
+				if ( $url && $url_host === $website_host ) {
 					$object = "url-{$url}";
 				}
+			}
+			if (!isset($object)) {
+				return $this->set_failure_response( 400, 'Could not determine text-object.' );
 			}
 
 			$text_allowed = $this->texts->get_allowed_text( $object );

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -51,6 +51,7 @@ class SettingsController
 				'supported_languages'                   => ydpl_resolve_from_container( 'ydpl.supported_target.languages' ),
 				'configured_supported_languages'        => ydpl_resolve_from_container( 'ydpl.site_options' )->configured_supported_languages(),
 				'rest_api_param_object_id_is_mandatory' => ydpl_resolve_from_container( 'ydpl.site_options' )->rest_api_param_object_id_is_mandatory(),
+				'secure_mode_enabled'                   => ydpl_resolve_from_container( 'ydpl.site_options' )->secure_mode_enabled(),
 			)
 		);
 	}

--- a/src/Providers/SettingsServiceProvider.php
+++ b/src/Providers/SettingsServiceProvider.php
@@ -104,5 +104,14 @@ class SettingsServiceProvider implements ServiceProviderInterface
 			'ydpl_section_rest_api',
 			array( 'settings_field_id' => 'ydpl_rest_api_param_object_id_is_mandatory' )
 		);
+
+		add_settings_field(
+			'ydpl_secure_mode_enabled',
+			__( 'Run translations in secure mode', 'yard-deepl' ),
+			array( $this->controller, 'section_fields_render' ),
+			'yard-deepl',
+			'ydpl_section_rest_api',
+			array( 'settings_field_id' => 'ydpl_secure_mode_enabled' )
+		);
 	}
 }

--- a/src/Providers/TextExtractionServiceProvider.php
+++ b/src/Providers/TextExtractionServiceProvider.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * A Text-extraction service provider.
+ *
+ * @package    YDPL\Providers
+ * @author     Remon Pel <remonpel@acato.nl>
+ * @subpackage YDPL\Providers\TextExtractionServiceProvider
+ */
+
+namespace YDPL\Providers;
+
+/**
+ * Exit when accessed directly.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use YDPL\Contracts\ServiceProviderInterface;
+use YDPL\Singletons\SiteOptionsSingleton;
+
+class TextExtractionServiceProvider implements ServiceProviderInterface {
+	protected SiteOptionsSingleton $options;
+
+	public function __construct() {
+		$this->options = ydpl_resolve_from_container( 'ydpl.site_options' );
+	}
+
+	public function register(): void {
+		add_action( 'save_post', array( $this, 'refresh_post_texts' ) );
+	}
+
+	public function refresh_post_texts( int $object_id ): void {
+		add_action( 'shutdown', function () use ( $object_id ) {
+			$this->get_allowed_text( $object_id, true );
+		} );
+	}
+
+	public function get_allowed_text( int $object_id, bool $refresh = false ): array {
+		// Get the stored list of allowed texts.
+		$allowed_text = get_post_meta( $object_id, 'ydpl_allowed_text', true );
+		if ( ! empty( $allowed_text ) && ! $refresh ) {
+			return $allowed_text['text'] ?? [];
+		}
+		// If we have no cache at all, we build it, cache it and return it.
+		$allowed_text = $this->extract_text( $object_id );
+		update_post_meta( $object_id, 'ydpl_allowed_text', [ 'text' => $allowed_text, 'timestamp' => microtime( true ) ] );
+
+		return $allowed_text;
+	}
+
+	public function extract_text( int $object_id ) {
+		// Get the post content.
+		$post = get_post( $object_id );
+		if ( ! $post ) {
+			return [];
+		}
+		$url = get_permalink( $object_id );
+
+		// Preserve user state.
+		$cookies = $_COOKIE;
+		$content = wp_remote_get( $url, [
+			'cookies' => $cookies,
+			'referer' => $url,
+		] );
+
+		if ( is_wp_error( $content ) ) {
+			return [];
+		}
+
+		$content = wp_remote_retrieve_body( $content );
+
+		if ( ! $content ) {
+			return [];
+		}
+
+		// Use DOM and xpath to extract the content.
+		$dom = new \DOMDocument();
+		@$dom->loadHTML( $content );
+		$xpath            = new \DOMXPath( $dom );
+		$content_selector = [
+			// A list of jQuery / CSS selectors to extract text from. We wil translate this list to xpath compatible selectors, this is this way for ease of maint.
+			'div',
+			'p',
+			'span',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'li',
+			'button',
+			'blockquote',
+			'a',
+			'label',
+			'details',
+			'summary',
+			'figcaption',
+			'code',
+			'pre',
+			'th',
+			'td',
+			'textarea',
+			'time',
+			'input[type="button"]',
+			'input[type="submit"]',
+			'input[type="reset"]',
+		];
+
+		$allowed_text = [];
+		foreach ( $content_selector as $selector ) {
+			$where = 'text';
+			if ( str_contains( $selector, '[' ) ) {
+				$selector = str_replace( '[', '[@', $selector );
+				// For now, this fits the bill. We can expand this later.
+				$where = 'attr-value';
+			}
+			$nodes          = $xpath->query( "*/{$selector}" );
+
+			$allowed_text = array_merge( $allowed_text, self::extract_from_dom_nodes( $nodes, $where ) );
+		}
+
+		foreach ( $nodes as $node ) {
+			$allowed_text[] = trim( $node->textContent );
+		}
+		if ( $allowed_text ) {
+			$allowed_text = array_unique( array_filter( array_map( 'trim', $allowed_text ) ), SORT_STRING );
+			usort( $allowed_text, 'strcasecmp' );
+		}
+
+		return $allowed_text;
+	}
+
+	/**
+	 * Array Intersect, but all strings are compared loosely to allow for accents, whitespace difference and case-insensitivity.
+	 *
+	 * @param string[] $text      List of texts to intersect. Items not in other lists will be removed.
+	 * @param string[] $intersect List of texts to intersect with.
+	 *
+	 * @return array
+	 */
+	public function array_intersect_loose( mixed $text, array $intersect ): array {
+		return array_uintersect( $text, $intersect, [ $this, 'compare_function' ] );
+	}
+
+	/**
+	 * Normalize a string for comparison.
+	 *
+	 * @param string $string_to_normalize The string to normalize.
+	 * @param string $encoding            The encoding of the string.
+	 *
+	 * @return string
+	 */
+	private static function normalize_string( $string_to_normalize, $encoding = "UTF-8" ) {
+		$string_to_normalize = trim( $string_to_normalize );
+		$string_to_normalize = preg_replace( '/\s+/', ' ', $string_to_normalize );
+		$string_to_normalize = preg_replace( '/&([^;])[^;]*;/', "$1", htmlentities( mb_strtolower( $string_to_normalize, $encoding ), null, $encoding ) );
+
+		return $string_to_normalize;
+	}
+
+	/**
+	 * Internal compare function for array_uintersect, for loose comparison.
+	 *
+	 * @param string $a A string.
+	 * @param string $b Another string.
+	 *
+	 * @return int
+	 */
+	private static function compare_function( $a, $b ) {
+		return strcmp( self::normalize_string( $a ), self::normalize_string( $b ) );
+	}
+
+	/**
+	 * Extract text from DOM nodes, recursively.
+	 *
+	 * @param \DOMNodeList $nodes List of DOM nodes.
+	 *                            Not strong typed in the signature to prevent errors in case a different library version gives a slightly different object.
+	 *
+	 * @return array
+	 */
+	private static function extract_from_dom_nodes( $nodes, $where = 'text' ): array {
+		$allowed_text = [];
+		foreach ( $nodes as $node ) {
+			$cnodes = $node->childNodes;
+			foreach ( $cnodes as $cnode ) { // we want 'if $cnodes', but that doesn't seem to work. Revisit.
+				$allowed_text = array_merge( $allowed_text, self::extract_from_dom_nodes( $cnodes, $where ) );
+				continue 2;
+			}
+			list( $where, $what ) = explode('-', $where .'-unknown' );
+			switch ( $where ) {
+				case 'text':
+				default:
+					$allowed_text[] = trim( $node->nodeValue );
+					break;
+				case 'attr':
+					$allowed_text[] = trim( $node->getAttribute($what) );
+					break;
+			}
+
+		}
+
+		return $allowed_text;
+	}
+}

--- a/src/Singletons/SiteOptionsSingleton.php
+++ b/src/Singletons/SiteOptionsSingleton.php
@@ -67,4 +67,14 @@ class SiteOptionsSingleton
 
 		return 'on' === $value;
 	}
+
+	/**
+	 * @since 0.0.1
+	 */
+	public function secure_mode_enabled(): bool
+	{
+		$value = $this->options['ydpl_secure_mode_enabled'] ?? '';
+
+		return 'on' === $value;
+	}
 }

--- a/src/Views/admin/partials/settings/settings-fields.php
+++ b/src/Views/admin/partials/settings/settings-fields.php
@@ -11,6 +11,7 @@ $settings_field_id                     = $settings_field_id ?? '';
 $supported_languages                   = is_array( $supported_languages ?? null ) ? $supported_languages : array();
 $configured_supported_languages        = is_array( $configured_supported_languages ?? null ) ? $configured_supported_languages : array();
 $rest_api_param_object_id_is_mandatory = $rest_api_param_object_id_is_mandatory ?? true;
+$secure_mode_enabled                   = $secure_mode_enabled ?? false;
 ?>
 
 <?php if ( $settings_field_id === 'ydpl_api_key' ) : ?>
@@ -29,4 +30,8 @@ $rest_api_param_object_id_is_mandatory = $rest_api_param_object_id_is_mandatory 
 
 <?php if ( $settings_field_id === 'ydpl_rest_api_param_object_id_is_mandatory' ) : ?>
 <input type="checkbox" name="ydpl_options[ydpl_rest_api_param_object_id_is_mandatory]" <?php echo $rest_api_param_object_id_is_mandatory ? 'checked' : ''; ?>>
+<?php endif; ?>
+
+<?php if ( $settings_field_id === 'ydpl_secure_mode_enabled' ) : ?>
+<input type="checkbox" name="ydpl_options[ydpl_secure_mode_enabled]" <?php echo $secure_mode_enabled ? 'checked' : ''; ?>>
 <?php endif; ?>


### PR DESCRIPTION
THIS IS A PROOF OF CONCEPT

Todo:

Verify the work ;)
The list provided by the FE (Front-End) with the current code (deepl.ts, other project) must at least be present in the strings generated by this PoC; otherwise, it’s not 100% backward compatible. The idea here is that this should be a drop-in replacement—the FE of, for example, existing implementations should continue to work as before, while this PoC ensures that no abuse can take place. In a new situation, the front-end should no longer need to send strings in the POST (fetch).

Some additional thoughts:

The plugin accepts POST requests with ObjectID = 0 when they are not required in settings. This is to handle cases like Archives. This is not covered by this PoC. 
We could implement "if object_id is 0, we take the referrer URL and retrieve the strings from there." 
It's safer than the current situation, but the URL must be validated to ensure "it’s really from one of our sites" (which is easy peasy). Caching can then be done based on URL, but that (as said) is not yet implemented.

For the plugin on [WordPress.org](http://wordpress.org/plugins/yard-deepl), it might be useful to include a demo script. Although the plugin does what it is supposed to do, it’s not very useful for someone who finds it without already having something in place for translating the site.